### PR TITLE
chore: update prettier peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/codfish/eslint-config-codfish#readme",
   "peerDependencies": {
     "eslint": "^4.19.1 || ^5.3.0",
-    "prettier": ">= 1.13.0"
+    "prettier": ">= 1.13.0 || ^1.16.0"
   },
   "engines": {
     "node": ">= 4"


### PR DESCRIPTION
allows latest 1.16 version to be installed