### PR TITLE
feat: create react module to allow for extending explicitly

### DIFF
--- a/react.js
+++ b/react.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['airbnb', 'prettier/react'],
+};


### PR DESCRIPTION
The dynamic support this config has for react applications is dependent
on the application having react as a dependency. In some situations its
possible you need react rules without it being a dependency. For instance
a generator that scaffolds out a react application would itself not be
dependent on react, but would just be building a react app that would
have jsx code, etc. In that case base config would error. So adding
this module would simply allow us to explicitly extend from the react
module as well, i.e. extends: `['codfish', 'codfish/react']`.