### PR TITLE
feat: bump babel eslint deps & update settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,17 +16,19 @@ module.exports = {
     'plugin:prettier/recommended',
   ].filter(Boolean),
 
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
 
   parserOptions: {
-    ecmaVersion: 2019,
+    requireConfigFile: false,
+    allowImportExportEverywhere: true,
+    ecmaVersion: 2021,
     sourceType: 'module',
     ecmaFeatures: {
       jsx: true,
     },
   },
 
-  plugins: ['babel'],
+  plugins: ['@babel'],
 
   rules: {
     ...reactRules,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/codfish/eslint-config-codfish#readme",
   "peerDependencies": {
+    "@babel/core": "^7.13.8",
     "eslint": "^7.5.0",
     "prettier": "^2.0.0"
   },
@@ -37,8 +38,9 @@
     "yarn": ">= 1"
   },
   "dependencies": {
+    "@babel/eslint-parser": "^7.13.8",
+    "@babel/eslint-plugin": "^7.13.0",
     "arrify": "^2.0.1",
-    "babel-eslint": "^10.0.3",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-kentcdodds": "^17.3.2",
@@ -51,6 +53,7 @@
     "read-pkg-up": "^7.0.1"
   },
   "devDependencies": {
+    "@babel/core": "7.13.8",
     "@commitlint/cli": "^12.0.0",
     "@commitlint/config-conventional": "^12.0.0",
     "eslint": "^7.20.0",

--- a/rules/babel.js
+++ b/rules/babel.js
@@ -1,40 +1,20 @@
 const style = require('eslint-config-airbnb-base/rules/style').rules;
 const bestPractices = require('eslint-config-airbnb-base/rules/best-practices').rules;
-const errors = require('eslint-config-airbnb-base/rules/errors').rules;
+
+// docs: https://github.com/babel/babel/tree/main/eslint/babel-eslint-plugin
 
 module.exports = {
   // turn off original rules
   'new-cap': 'off',
-  camelcase: 'off',
   'no-invalid-this': 'off',
   'object-curly-spacing': 'off',
   semi: 'off',
   'no-unused-expressions': 'off',
-  'valid-typeof': 'off',
-  'generator-star-spacing': 'off',
-  'object-shorthand': 'off',
-  'arrow-parens': 'off',
-  'func-params-comma-dangle': 'off',
-  'array-bracket-spacing': 'off',
-  'flow-object-type': 'off',
-  'no-await-in-loop': 'off',
 
   // set rules
-  'babel/new-cap': style['new-cap'],
-  'babel/camelcase': style.camelcase,
-  'babel/no-invalid-this': bestPractices['no-invalid-this'],
-  'babel/object-curly-spacing': style['object-curly-spacing'],
-  'babel/semi': style.semi,
-  'babel/no-unused-expressions': bestPractices['no-unused-expressions'],
-  'babel/valid-typeof': errors['valid-typeof'],
-
-  // deprecated or soon to be
-  'babel/quotes': 'off',
-  'babel/generator-star-spacing': 'off',
-  'babel/object-shorthand': 'off',
-  'babel/arrow-parens': 'off',
-  'babel/func-params-comma-dangle': 'off',
-  'babel/array-bracket-spacing': 'off',
-  'babel/flow-object-type': 'off',
-  'babel/no-await-in-loop': 'off',
+  '@babel/new-cap': style['new-cap'],
+  '@babel/no-invalid-this': bestPractices['no-invalid-this'],
+  '@babel/no-unused-expressions': bestPractices['no-unused-expressions'],
+  '@babel/object-curly-spacing': style['object-curly-spacing'],
+  '@babel/semi': style.semi,
 };


### PR DESCRIPTION
BREAKING CHANGE: Migrated from deprecated babel plugins to
the new @babel monorepo versions. Because of this, all of
the babel rules are now prexifixed with '@babel/<rule-name>'
instead of 'babel/<rule-name>'.

Also, a number of babel rules were deprecated so they may give
errors or warnings when running eslint. The only rules being
re-set are:

- `@babel/new-cap`
- `@babel/no-invalid-this`
- `@babel/no-unused-expressions`
- `@babel/object-curly-spacing`
- `@babel/semi`

<!-- Brief description of the code changes. Add supporting screenshots & videos where applicable. -->

**Related Issue**: https://github.com/codfish/eslint-config-codfish/issues/**NUMBER**

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [ ] I have reviewed the code changes myself
- [ ] My code meets all of the acceptance criteria of the ticket it closes.
- [ ] I have made all necessary changes to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Any dependent changes have been merged and published.
