### PR TITLE
fix: revert "feat: bump babel eslint deps & update settings"

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,19 +16,17 @@ module.exports = {
     'plugin:prettier/recommended',
   ].filter(Boolean),
 
-  parser: '@babel/eslint-parser',
+  parser: 'babel-eslint',
 
   parserOptions: {
-    requireConfigFile: false,
-    allowImportExportEverywhere: true,
-    ecmaVersion: 2021,
+    ecmaVersion: 2019,
     sourceType: 'module',
     ecmaFeatures: {
       jsx: true,
     },
   },
 
-  plugins: ['@babel'],
+  plugins: ['babel'],
 
   rules: {
     ...reactRules,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "homepage": "https://github.com/codfish/eslint-config-codfish#readme",
   "peerDependencies": {
-    "@babel/core": "^7.13.8",
     "eslint": "^7.5.0",
     "prettier": "^2.0.0"
   },
@@ -38,9 +37,8 @@
     "yarn": ">= 1"
   },
   "dependencies": {
-    "@babel/eslint-parser": "^7.13.8",
-    "@babel/eslint-plugin": "^7.13.0",
     "arrify": "^2.0.1",
+    "babel-eslint": "^10.0.3",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-kentcdodds": "^17.3.2",
@@ -53,7 +51,6 @@
     "read-pkg-up": "^7.0.1"
   },
   "devDependencies": {
-    "@babel/core": "7.13.8",
     "@commitlint/cli": "^12.0.0",
     "@commitlint/config-conventional": "^12.0.0",
     "eslint": "^7.20.0",

--- a/rules/babel.js
+++ b/rules/babel.js
@@ -1,20 +1,40 @@
 const style = require('eslint-config-airbnb-base/rules/style').rules;
 const bestPractices = require('eslint-config-airbnb-base/rules/best-practices').rules;
-
-// docs: https://github.com/babel/babel/tree/main/eslint/babel-eslint-plugin
+const errors = require('eslint-config-airbnb-base/rules/errors').rules;
 
 module.exports = {
   // turn off original rules
   'new-cap': 'off',
+  camelcase: 'off',
   'no-invalid-this': 'off',
   'object-curly-spacing': 'off',
   semi: 'off',
   'no-unused-expressions': 'off',
+  'valid-typeof': 'off',
+  'generator-star-spacing': 'off',
+  'object-shorthand': 'off',
+  'arrow-parens': 'off',
+  'func-params-comma-dangle': 'off',
+  'array-bracket-spacing': 'off',
+  'flow-object-type': 'off',
+  'no-await-in-loop': 'off',
 
   // set rules
-  '@babel/new-cap': style['new-cap'],
-  '@babel/no-invalid-this': bestPractices['no-invalid-this'],
-  '@babel/no-unused-expressions': bestPractices['no-unused-expressions'],
-  '@babel/object-curly-spacing': style['object-curly-spacing'],
-  '@babel/semi': style.semi,
+  'babel/new-cap': style['new-cap'],
+  'babel/camelcase': style.camelcase,
+  'babel/no-invalid-this': bestPractices['no-invalid-this'],
+  'babel/object-curly-spacing': style['object-curly-spacing'],
+  'babel/semi': style.semi,
+  'babel/no-unused-expressions': bestPractices['no-unused-expressions'],
+  'babel/valid-typeof': errors['valid-typeof'],
+
+  // deprecated or soon to be
+  'babel/quotes': 'off',
+  'babel/generator-star-spacing': 'off',
+  'babel/object-shorthand': 'off',
+  'babel/arrow-parens': 'off',
+  'babel/func-params-comma-dangle': 'off',
+  'babel/array-bracket-spacing': 'off',
+  'babel/flow-object-type': 'off',
+  'babel/no-await-in-loop': 'off',
 };


### PR DESCRIPTION
This reverts commit bf893e6184e919ebd65ff3ad0c8e6e818c945309.

issues being caused by new version of babel's ESLint parser requiring babel/core and possibly not passing the builtin babel config. getting weird errors when adding this version to `cod-scripts`

```
/Users/codonnell/Sites/orca/components/GatheringDetailCard.js
  0:0  error  Parsing error: [BABEL]: You should add @babel/runtime as dependency to your package. It will allow reusing "babel helpers" from node_modules rather than bundling their copies into your files. (While processing: /Users/codonnell/Sites/orca/node_modules/cod-scripts/babel.js)
```

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/1666298/109899797-6485db80-7c64-11eb-80f1-9b583e14f762.png">
